### PR TITLE
Pre deploy

### DIFF
--- a/src/main/java/mapwriter/Mw.java
+++ b/src/main/java/mapwriter/Mw.java
@@ -116,6 +116,7 @@ public class Mw {
 	public int backgroundTextureMode = 0;
 	public boolean newMarkerDialog = true;
 	//public boolean lightingEnabled = false;
+	public boolean paintChunks = false;
 	
 	// flags and counters
 	private boolean onPlayerDeathAlreadyFired = false;
@@ -227,6 +228,7 @@ public class Mw {
 		this.backgroundTextureMode = this.config.getOrSetInt(catOptions, "backgroundTextureMode", this.backgroundTextureMode, 0, 1);
 		//this.lightingEnabled = this.config.getOrSetBoolean(catOptions, "lightingEnabled", this.lightingEnabled);
 		this.newMarkerDialog = this.config.getOrSetBoolean(catOptions, "newMarkerDialog", this.newMarkerDialog);
+		this.paintChunks = this.config.getOrSetBoolean("options", "paintChunks", this.paintChunks);
 
 		/*MwUtil.log("maxZoomAfter(%d)", this.maxZoom);
 		MwUtil.log("minZoomAfter(%d)", this.minZoom);*/
@@ -266,7 +268,7 @@ public class Mw {
 		this.config.setInt(catOptions, "backgroundTextureMode", this.backgroundTextureMode);
 		//this.config.setBoolean(catOptions, "lightingEnabled", this.lightingEnabled);
 		this.config.setBoolean(catOptions, "newMarkerDialog", this.newMarkerDialog);
-
+		this.config.setBoolean("options", "paintChunks", this.paintChunks);
 		this.config.save();	
 	}
 	

--- a/src/main/java/mapwriter/Mw.java
+++ b/src/main/java/mapwriter/Mw.java
@@ -767,7 +767,11 @@ public void saveCfgAndMarkers() {
 				this.markerManager.nextGroup();
 				this.markerManager.update();
 				this.mc.thePlayer.addChatMessage(new ChatComponentText("group " + this.markerManager.getVisibleGroupName() + " selected"));
-				
+			} else if (kb == MwKeyHandler.keyPrevGroup) {
+				// toggle marker mode
+				this.markerManager.prevGroup();
+				this.markerManager.update();
+				this.mc.thePlayer.addChatMessage(new ChatComponentText("group " + this.markerManager.getVisibleGroupName() + " selected"));
 			} else if (kb == MwKeyHandler.keyTeleport) {
 				// set or remove marker
 				Marker marker = this.markerManager.getNearestMarkerInDirection(

--- a/src/main/java/mapwriter/api/IMwChunkOverlay.java
+++ b/src/main/java/mapwriter/api/IMwChunkOverlay.java
@@ -5,8 +5,10 @@ import java.awt.Point;
 public interface IMwChunkOverlay {
 	public Point   getCoordinates();
 	public int     getColor();
+	public int 	   getColorFromXY(int X, int Z);
 	public float   getFilling();
 	public boolean hasBorder();
 	public float   getBorderWidth();
 	public int     getBorderColor();
+	public boolean getPaintChunks();
 }

--- a/src/main/java/mapwriter/forge/ClientProxy.java
+++ b/src/main/java/mapwriter/forge/ClientProxy.java
@@ -4,6 +4,7 @@ import java.io.File;
 
 import mapwriter.Mw;
 import mapwriter.api.MwAPI;
+import mapwriter.overlay.OverlayFluidsGrid;
 import mapwriter.overlay.OverlayGrid;
 import mapwriter.overlay.OverlaySlime;
 import mapwriter.region.MwChunk;
@@ -45,6 +46,7 @@ public class ClientProxy extends CommonProxy {
 		}
 		MwAPI.registerDataProvider("Slime", new OverlaySlime());
 		MwAPI.registerDataProvider("Grid", new OverlayGrid());
+		MwAPI.registerDataProvider("FluidsGrid", new OverlayFluidsGrid());
 		// MwAPI.registerDataProvider("Checker", new OverlayChecker());
 		// MwAPI.setCurrentDataProvider("Slime");
 	}

--- a/src/main/java/mapwriter/forge/MwKeyHandler.java
+++ b/src/main/java/mapwriter/forge/MwKeyHandler.java
@@ -21,12 +21,13 @@ public class MwKeyHandler {
 	public static KeyBinding keyNewMarker = new KeyBinding("key.mw_new_marker", Keyboard.KEY_INSERT, "Mapwriter");
 	public static KeyBinding keyMapMode = new KeyBinding("key.mw_next_map_mode", Keyboard.KEY_N, "Mapwriter");
 	public static KeyBinding keyNextGroup = new KeyBinding("key.mw_next_marker_group", Keyboard.KEY_COMMA, "Mapwriter");
-	public static KeyBinding keyTeleport = new KeyBinding("key.mw_teleport", Keyboard.KEY_PERIOD, "Mapwriter");
+	public static KeyBinding keyPrevGroup = new KeyBinding("key.mw_prev_marker_group", Keyboard.KEY_PERIOD, "Mapwriter");
+	public static KeyBinding keyTeleport = new KeyBinding("key.mw_teleport", Keyboard.KEY_RSHIFT, "Mapwriter");
 	public static KeyBinding keyZoomIn = new KeyBinding("key.mw_zoom_in", Keyboard.KEY_PRIOR, "Mapwriter");
 	public static KeyBinding keyZoomOut = new KeyBinding("key.mw_zoom_out", Keyboard.KEY_NEXT, "Mapwriter");
 	public static KeyBinding keyUndergroundMode = new KeyBinding("key.mw_underground_mode", Keyboard.KEY_U, "Mapwriter");
 	//public static KeyBinding keyQuickLargeMap = new KeyBinding("key.mw_quick_large_map", Keyboard.KEY_NONE);
-	
+
 	public final KeyBinding[] keys = 
 		{
 			keyMapGui,
@@ -36,7 +37,9 @@ public class MwKeyHandler {
 			keyTeleport,
 			keyZoomIn,
 			keyZoomOut,
-			keyUndergroundMode
+			keyUndergroundMode,
+			keyPrevGroup
+
 	};
 	
 	public MwKeyHandler()

--- a/src/main/java/mapwriter/gui/MwGui.java
+++ b/src/main/java/mapwriter/gui/MwGui.java
@@ -113,6 +113,8 @@ public class MwGui extends GuiScreen {
     // called when gui is displayed and every time the screen
     // is resized
     public void initGui() {
+		//enable key pressed in Textfields
+    	Keyboard.enableRepeatEvents(true);
 //    	this.buttonList.add(this.optionsButton = new MwGuiButton(0, this.width - 25, this.height / 2 - 20));
     }
 
@@ -305,6 +307,9 @@ public class MwGui extends GuiScreen {
     		} else if (key == MwKeyHandler.keyNextGroup.getKeyCode()) {
     			this.mw.markerManager.nextGroup();
 	        	this.mw.markerManager.update();
+			} else if (key == MwKeyHandler.keyPrevGroup.getKeyCode()) {
+				this.mw.markerManager.prevGroup();
+				this.mw.markerManager.update();
     		} else if (key == MwKeyHandler.keyUndergroundMode.getKeyCode()) {
     			this.mw.toggleUndergroundMode();
     			this.mapView.setUndergroundMode(this.mw.undergroundMode);
@@ -379,14 +384,28 @@ public class MwGui extends GuiScreen {
 			if ((marker != null) && (prevMarker == marker)) {
     			// right clicked previously selected marker.
     			// edit the marker
-				this.mc.displayGuiScreen(
-        			new MwGuiMarkerDialog(
-        				this,
-        				this.mw.markerManager,
-        				marker
-        			)
-        		);
-    			
+
+				if (mw.newMarkerDialog)
+				{
+					this.mc.displayGuiScreen(
+							new MwGuiMarkerDialogNew(
+									this,
+									this.mw.markerManager,
+									marker
+							)
+					);
+				}
+				else
+				{
+					this.mc.displayGuiScreen(
+							new MwGuiMarkerDialog(
+									this,
+									this.mw.markerManager,
+									marker
+							)
+					);
+				}
+
     		} else if (marker == null) {
     			// open new marker dialog
     			String group = this.mw.markerManager.getVisibleGroupName();

--- a/src/main/java/mapwriter/gui/MwGuiMarkerDialogNew.java
+++ b/src/main/java/mapwriter/gui/MwGuiMarkerDialogNew.java
@@ -370,8 +370,10 @@ public class MwGuiMarkerDialogNew extends GuiScreen
 
 	@Override
 	public void handleMouseInput() {
+	/*  if overlay is enabled it is impossible to use mouse actions(click, wheel Up/Down) on GUI New Marker Manager
 		if (MwAPI.getCurrentDataProvider() != null)
 			return;
+	 */
 		int x = Mouse.getEventX() * this.width / this.mc.displayWidth;
 		int y = this.height - Mouse.getEventY() * this.height
 				/ this.mc.displayHeight - 1;

--- a/src/main/java/mapwriter/gui/MwGuiMarkerSearch.java
+++ b/src/main/java/mapwriter/gui/MwGuiMarkerSearch.java
@@ -4,6 +4,7 @@ import mapwriter.Mw;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.resources.I18n;
+import org.lwjgl.input.Keyboard;
 
 public class MwGuiMarkerSearch extends GuiScreen {
 
@@ -26,9 +27,13 @@ public class MwGuiMarkerSearch extends GuiScreen {
     }
 
     protected void keyTyped(char c, int k) {
-        super.keyTyped(c, k);
-        this.textField.textboxKeyTyped(c, k);
-        this.markerSlot.updateMarkerList(this.textField.getText());
+        if (k==Keyboard.KEY_ESCAPE){
+            this.mc.displayGuiScreen(this.parentScreen);
+        }else{
+            super.keyTyped(c, k);
+            this.textField.textboxKeyTyped(c, k);
+            this.markerSlot.updateMarkerList(this.textField.getText());
+        }
     }
 
     protected void mouseClicked(int x, int y, int btn) {

--- a/src/main/java/mapwriter/gui/MwGuiOptionSlot.java
+++ b/src/main/java/mapwriter/gui/MwGuiOptionSlot.java
@@ -39,7 +39,7 @@ public class MwGuiOptionSlot extends GuiSlot {
 	};
 	private static final int[] ticksBetweenUpdatesIntArray = {0, 20, 40, 60, 100, 200, 300, 400, 500, 750, 1000};
 
-	private GuiButton[] buttons = new GuiButton[14];
+	private GuiButton[] buttons = new GuiButton[15];
 	
     static final ResourceLocation WIDGET_TEXTURE_LOC = new ResourceLocation("textures/gui/widgets.png");
 	
@@ -89,6 +89,9 @@ public class MwGuiOptionSlot extends GuiSlot {
 			//	break;
 			case 13:
 				this.buttons[i].displayString = I18n.format("mw.gui.mwguioptionslot.oldNewMarkerDialog", (this.mw.newMarkerDialog ? I18n.format("mw.gui.mwguioptionslot.oldNewMarkerDialog.new") : I18n.format("mw.gui.mwguioptionslot.oldNewMarkerDialog.old")));
+				break;
+			case 14:
+				this.buttons[i].displayString = I18n.format("mw.gui.mwguioptionslot.paintOverChunk",this.mw.paintChunks);
 				break;
 			default:
 				break;
@@ -211,6 +214,9 @@ public class MwGuiOptionSlot extends GuiSlot {
 			//	break;
 			case 13:
 				this.mw.newMarkerDialog = !this.mw.newMarkerDialog;
+				break;
+			case 14:
+				this.mw.paintChunks = !this.mw.paintChunks;
 				break;
 			default:
 				break;

--- a/src/main/java/mapwriter/map/MapRenderer.java
+++ b/src/main/java/mapwriter/map/MapRenderer.java
@@ -1,6 +1,7 @@
 package mapwriter.map;
 
 import java.awt.Point;
+import java.awt.geom.Point2D;
 import java.util.ArrayList;
 
 import mapwriter.Mw;
@@ -289,35 +290,44 @@ public class MapRenderer {
 	}
 	
 	private static void paintChunk(MapMode mapMode, MapView mapView, IMwChunkOverlay overlay){
-		int chunkX    = overlay.getCoordinates().x;
-		int chunkZ    = overlay.getCoordinates().y;
+		int chunkX = overlay.getCoordinates().x;
+		int chunkZ = overlay.getCoordinates().y;
 		float filling = overlay.getFilling();
-		
-		Point.Double topCorner = mapMode.blockXZtoScreenXY(mapView, chunkX << 4, chunkZ << 4);
-		Point.Double botCorner = mapMode.blockXZtoScreenXY(mapView, (chunkX + 1) << 4, (chunkZ + 1 << 4));
+		boolean paintChunks = overlay.getPaintChunks();
+		Point2D.Double topCorner;
+		Point2D.Double botCorner;
+		if (MwAPI.getCurrentProviderName() != "FluidsGrid") {
+			topCorner = mapMode.blockXZtoScreenXY(mapView, (double)(chunkX << 4), (double)(chunkZ << 4));
+			botCorner = mapMode.blockXZtoScreenXY(mapView, (double)(chunkX + 1 << 4), (double)(chunkZ + 1 << 4));
+		} else {
+			topCorner = mapMode.blockXZtoScreenXY(mapView, (double)(chunkX * 96), (double)(chunkZ * 96));
+			botCorner = mapMode.blockXZtoScreenXY(mapView, (double)((chunkX + 1) * 96), (double)((chunkZ + 1) * 96));
+		}
 
-		topCorner.x = Math.max(mapMode.x,             topCorner.x);
-		topCorner.x = Math.min(mapMode.x + mapMode.w, topCorner.x);
-		topCorner.y = Math.max(mapMode.y,             topCorner.y);
-		topCorner.y = Math.min(mapMode.y + mapMode.h, topCorner.y);
-		
-		botCorner.x = Math.max(mapMode.x,             botCorner.x);
-		botCorner.x = Math.min(mapMode.x + mapMode.w, botCorner.x);
-		botCorner.y = Math.max(mapMode.y,             botCorner.y);
-		botCorner.y = Math.min(mapMode.y + mapMode.h, botCorner.y);		
-
-		double sizeX = (botCorner.x - topCorner.x) * filling;
-		double sizeY = (botCorner.y - topCorner.y) * filling;		
-		double offsetX = ((botCorner.x - topCorner.x) - sizeX) / 2;
-		double offsetY = ((botCorner.y - topCorner.y) - sizeY) / 2;	
-		
+		topCorner.x = Math.max((double)mapMode.x, topCorner.x);
+		topCorner.x = Math.min((double)(mapMode.x + mapMode.w), topCorner.x);
+		topCorner.y = Math.max((double)mapMode.y, topCorner.y);
+		topCorner.y = Math.min((double)(mapMode.y + mapMode.h), topCorner.y);
+		botCorner.x = Math.max((double)mapMode.x, botCorner.x);
+		botCorner.x = Math.min((double)(mapMode.x + mapMode.w), botCorner.x);
+		botCorner.y = Math.max((double)mapMode.y, botCorner.y);
+		botCorner.y = Math.min((double)(mapMode.y + mapMode.h), botCorner.y);
+		double sizeX = (botCorner.x - topCorner.x) * (double)filling;
+		double sizeY = (botCorner.y - topCorner.y) * (double)filling;
+		double offsetX = (botCorner.x - topCorner.x - sizeX) / 2.0D;
+		double offsetY = (botCorner.y - topCorner.y - sizeY) / 2.0D;
 		if (overlay.hasBorder()) {
 			Render.setColour(overlay.getBorderColor());
-			Render.drawRectBorder(topCorner.x + 1, topCorner.y + 1, botCorner.x - topCorner.x - 1, botCorner.y - topCorner.y - 1, overlay.getBorderWidth());
+			Render.drawRectBorder(topCorner.x + 1.0D, topCorner.y + 1.0D, botCorner.x - topCorner.x - 1.0D, botCorner.y - topCorner.y - 1.0D, (double)overlay.getBorderWidth());
 		}
-		
-		Render.setColour(overlay.getColor());
-		Render.drawRect(topCorner.x + offsetX + 1, topCorner.y + offsetY + 1, sizeX - 1, sizeY - 1);
+
+		if (MwAPI.getCurrentProviderName() == "FluidsGrid" && overlay.getPaintChunks()) {
+			Render.setColour(overlay.getColorFromXY(chunkX * 96, chunkZ * 96));
+		} else {
+			Render.setColour(overlay.getColor());
+		}
+
+		Render.drawRect(topCorner.x + offsetX + 1.0D, topCorner.y + offsetY + 1.0D, sizeX - 1.0D, sizeY - 1.0D);
 	}
 }
 

--- a/src/main/java/mapwriter/map/MarkerManager.java
+++ b/src/main/java/mapwriter/map/MarkerManager.java
@@ -63,7 +63,12 @@ public class MarkerManager {
 	
 	public void setVisibleGroupName(String groupName) {
 		if (groupName != null) {
-			this.visibleGroupName = MwUtil.mungeString(groupName);
+			//If the group name contains an special character(".","-"," ","/","\"),
+			// then when you exit Add/Edit Marker GUI on the fullscreen, the current of markers group is set to "none"
+			//But, in the the group name this special is saved with special characters
+
+			//this.visibleGroupName = MwUtil.mungeString(groupName);
+			this.visibleGroupName = groupName;
 		} else {
 			this.visibleGroupName = "none";
 		}
@@ -202,7 +207,13 @@ public class MarkerManager {
 	public void nextGroup() {
 		this.nextGroup(1);
 	}
-	
+
+	public void prevGroup(int n) {	this.nextGroup(n);	}
+
+	public void prevGroup() {
+		this.nextGroup(-1);
+	}
+
 	public int countMarkersInGroup(String group) {
 		int count = 0;
 		if (group.equals("all")) {

--- a/src/main/java/mapwriter/overlay/OverlayChecker.java
+++ b/src/main/java/mapwriter/overlay/OverlayChecker.java
@@ -37,6 +37,12 @@ public class OverlayChecker implements IMwDataProvider {
 
 		@Override
 		public int getBorderColor() { return 0xff000000; }
+
+		@Override
+		public int getColorFromXY(int X, int Z) { return 0x00ffffff;}
+
+		@Override
+		public boolean getPaintChunks() {	return false; }
 		
 	}
 	

--- a/src/main/java/mapwriter/overlay/OverlayFluidsGrid.java
+++ b/src/main/java/mapwriter/overlay/OverlayFluidsGrid.java
@@ -1,0 +1,123 @@
+package mapwriter.overlay;
+
+import java.awt.Point;
+import java.util.ArrayList;
+import java.util.Iterator;
+import mapwriter.Mw;
+import mapwriter.api.IMwChunkOverlay;
+import mapwriter.api.IMwDataProvider;
+import mapwriter.map.MapView;
+import mapwriter.map.Marker;
+import mapwriter.map.mapmode.MapMode;
+import net.minecraft.util.MathHelper;
+
+public class OverlayFluidsGrid implements IMwDataProvider {
+    public OverlayFluidsGrid() {
+    }
+
+    public ArrayList<IMwChunkOverlay> getChunksOverlay(Mw mw, int dim, double centerX, double centerZ, double minX, double minZ, double maxX, double maxZ) {
+        int minChunkX = MathHelper.ceiling_double_int(minX) / 96 - 1;
+        int minChunkZ = MathHelper.ceiling_double_int(minZ) / 96 - 1;
+        int maxChunkX = MathHelper.ceiling_double_int(maxX) / 96 + 1;
+        int maxChunkZ = MathHelper.ceiling_double_int(maxZ) / 96 + 1;
+        int cX = MathHelper.ceiling_double_int(centerX) / 96 + 1;
+        int cZ = MathHelper.ceiling_double_int(centerZ) / 96 + 1;
+        int limitMinX = Math.max(minChunkX, cX - 96);
+        int limitMaxX = Math.min(maxChunkX, cX + 96);
+        int limitMinZ = Math.max(minChunkZ, cZ - 96);
+        int limitMaxZ = Math.min(maxChunkZ, cZ + 96);
+        ArrayList<IMwChunkOverlay> chunks = new ArrayList();
+
+        for(int x = limitMinX; x <= limitMaxX; ++x) {
+            for(int z = limitMinZ; z <= limitMaxZ; ++z) {
+                chunks.add(new OverlayFluidsGrid.ChunkOverlay(mw, x, z));
+            }
+        }
+
+        return chunks;
+    }
+
+    public String getStatusString(int dim, int bX, int bY, int bZ) {
+        return "";
+    }
+
+    public void onMiddleClick(int dim, int bX, int bZ, MapView mapview) {
+    }
+
+    public void onDimensionChanged(int dimension, MapView mapview) {
+    }
+
+    public void onMapCenterChanged(double vX, double vZ, MapView mapview) {
+    }
+
+    public void onZoomChanged(int level, MapView mapview) {
+    }
+
+    public void onOverlayActivated(MapView mapview) {
+    }
+
+    public void onOverlayDeactivated(MapView mapview) {
+    }
+
+    public void onDraw(MapView mapview, MapMode mapmode) {
+    }
+
+    public boolean onMouseInput(MapView mapview, MapMode mapmode) {
+        return false;
+    }
+
+    public class ChunkOverlay implements IMwChunkOverlay {
+        private Mw mw;
+        Point coord;
+        float borderWidth = 0.5F;
+        boolean ChunkHasBorder = true;
+
+        public ChunkOverlay(Mw mw, int x, int z) {
+            this.mw = mw;
+            this.coord = new Point(x, z);
+        }
+
+        public Point getCoordinates() {
+            return this.coord;
+        }
+
+        public int getColor() {
+            return 16777215;
+        }
+
+        public int getColorFromXY(int X, int Z) {
+            String CurrentGroup = this.mw.markerManager.getVisibleGroupName();
+            Iterator var4 = this.mw.markerManager.markerList.iterator();
+
+            Marker marker;
+            do {
+                if (!var4.hasNext()) {
+                    return 0;
+                }
+
+                marker = (Marker)var4.next();
+            } while(marker.x <= X || marker.x >= X + 96 || !marker.groupName.equals(CurrentGroup) || marker.z <= Z || marker.z >= Z + 96);
+
+            String color = String.format("%1$02X", marker.colour >> 16 & 255) + String.format("%1$02X", marker.colour >> 8 & 255) + String.format("%1$02X", marker.colour & 255);
+            return -2147483648 | Integer.parseInt(color, 16);
+        }
+
+        public boolean getPaintChunks() {   return this.mw.paintChunks;}
+
+        public float getFilling() {
+            return 1.0F;
+        }
+
+        public boolean hasBorder() {
+            return this.ChunkHasBorder;
+        }
+
+        public float getBorderWidth() {
+            return this.borderWidth;
+        }
+
+        public int getBorderColor() {
+            return this.mw.backgroundTextureMode == 0 ? -2145315826 : -16777216;
+        }
+    }
+}

--- a/src/main/java/mapwriter/overlay/OverlayGrid.java
+++ b/src/main/java/mapwriter/overlay/OverlayGrid.java
@@ -46,7 +46,12 @@ public class OverlayGrid implements IMwDataProvider {
 				return 0xff000000;
 			}
 		}
-		
+
+		@Override
+		public int getColorFromXY(int X, int Z) { return 0x00ffffff;}
+
+		@Override
+		public boolean getPaintChunks() {	return false; }
 	}
 	
 	@Override

--- a/src/main/java/mapwriter/overlay/OverlaySlime.java
+++ b/src/main/java/mapwriter/overlay/OverlaySlime.java
@@ -62,7 +62,12 @@ public class OverlaySlime implements IMwDataProvider {
 
 		@Override
 		public int getBorderColor() { return 0xff000000; }
-		
+
+		@Override
+		public int getColorFromXY(int X, int Z) { return 0x00ffffff;}
+
+		@Override
+		public boolean getPaintChunks() {	return false; }
 	}
 	
 	@Override

--- a/src/main/resources/assets/mapwriter/lang/en_US.lang
+++ b/src/main/resources/assets/mapwriter/lang/en_US.lang
@@ -101,3 +101,4 @@ mw.gui.mwguioptionslot.backgroundMode.panning=panning
 mw.gui.mwguioptionslot.oldNewMarkerDialog=Old/New Marker Dialog: %s
 mw.gui.mwguioptionslot.oldNewMarkerDialog.new=New
 mw.gui.mwguioptionslot.oldNewMarkerDialog.old=Old
+mw.gui.mwguioptionslot.paintOverChunk=Paint over chunk: %s

--- a/src/main/resources/assets/mapwriter/lang/en_US.lang
+++ b/src/main/resources/assets/mapwriter/lang/en_US.lang
@@ -3,6 +3,7 @@ key.mw_open_gui=Open map GUI
 key.mw_new_marker=New Waypoint
 key.mw_next_map_mode=Next map mode
 key.mw_next_marker_group=Next waypoint group
+key.mw_prev_marker_group=Previous waypoint group
 key.mw_teleport=Teleport to waypoint
 key.mw_zoom_in=Minimap zoom in
 key.mw_zoom_out=Minimap zoom out

--- a/src/main/resources/assets/mapwriter/lang/ru_RU.lang
+++ b/src/main/resources/assets/mapwriter/lang/ru_RU.lang
@@ -3,6 +3,7 @@ key.mw_open_gui=Открыть карту
 key.mw_new_marker=Новый маркер
 key.mw_next_map_mode=След. режим карты
 key.mw_next_marker_group=След. группа маркеров
+key.mw_prev_marker_group=Пред. группа маркеров
 key.mw_teleport=Телепорт к маркеру
 key.mw_zoom_in=Приближение
 key.mw_zoom_out=Отдаление

--- a/src/main/resources/assets/mapwriter/lang/ru_RU.lang
+++ b/src/main/resources/assets/mapwriter/lang/ru_RU.lang
@@ -101,3 +101,4 @@ mw.gui.mwguioptionslot.backgroundMode.panning=панорамирование
 mw.gui.mwguioptionslot.oldNewMarkerDialog=Старое/новое окно созд. маркера: %s
 mw.gui.mwguioptionslot.oldNewMarkerDialog.new=Новое
 mw.gui.mwguioptionslot.oldNewMarkerDialog.old=Старое
+mw.gui.mwguioptionslot.paintOverChunk=Закрашивать чанки: %s


### PR DESCRIPTION
Добавил способ редактирования меток в новом меню.
Исправил  меню добавления/редактирования маркера, чтобы работали клики мыши и колеса(там это работало только при откл. оверлее карты),
Исправил повторное нажатие клавиш в текстовых полях меню(включил enableRepeatEvents() в обработчике  LWJGL)
Добавил хоткей листания групп маркеров назад(было только вперед), перебиндил хоткей телепорта на Right Shift(в настройках майн нужно поправить, т.к. сохраненные настройки не трогает). 
Добавил выход по клавише ESC из меню поиска маркеров на карту, а не в игру. 
При создании маркера, если в названии группы были опред. символы  (".","-"," ","/",""), то хотя эти символы и сохранялись в имени группы, но при создании маркера текущая группа сбрасывалась на "none"
Добавил новый оверлей на карту, рисует сетку с размерами 6x6 чанков от координат 0,0. Чтобы видно было расположение месторождений жидкостей под бедроком. Можно настройках mapwriter включить опцию закрашивать чанки(paint over chunk) в этом оверлее. Закрашивает цветом  маркера, который в этом чанке расположен с альфа-каналом. Маркер берется первый, который в этом чанке есть